### PR TITLE
Fix `std::less<SAGEExpr>` specialization namespace.

### DIFF
--- a/SAGEExpr.h
+++ b/SAGEExpr.h
@@ -103,12 +103,14 @@ private:
   PyObject *Expr_;
 };
 
-template <>
-struct std::less<SAGEExpr> {
-  bool operator() (const SAGEExpr& LHS, const SAGEExpr& RHS) const {
-    return LHS.compare(RHS) < 0;
-  }
-};
+namespace std {
+  template <>
+  struct less<SAGEExpr> {
+    bool operator() (const SAGEExpr& LHS, const SAGEExpr& RHS) const {
+      return LHS.compare(RHS) < 0;
+    }
+  };
+}
 
 #endif
 


### PR DESCRIPTION
When specializing a template from some namespace `foo`, the specialization must itself be declared within `namespace foo { ... }`.  It's not enough to just prefix the specialization with `foo::`.  For more information and commentary, see:
- [warning: specialization of template in different namespace](http://stackoverflow.com/q/25594644/91929)
- [Specialization of 'template<class _Tp> struct std::less' in different namespace](http://stackoverflow.com/q/2282349/91929)
- [Can explicit specialization outside namespace use qualified name?](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#374)
- [Explicit specialization in a namespace enclosing the specialized template](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480)

Note that it is only necessary to _declare_ the specialization in this manner; it is not required to also _define_ the specialization within namespace curly brackets.  However, one is allowed to do that where convenient, as I have done here.

This fixes a build failure with g++-4.8.3, and probably with many other gcc and clang versions as well.
