### PR TITLE
Explicitly abort after assertion that always fails

### DIFF
--- a/SAGEExpr.cpp
+++ b/SAGEExpr.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Debug.h"
 
+#include <cstdlib>
 #include <map>
 #include <string>
 
@@ -319,6 +320,7 @@ Value *SAGEExpr::toValue(IntegerType *Ty, IRBuilder<> &IRB,
   }
 
   assert(false && "Unhandled expression");
+  std::abort();
 }
 
 void SAGEExpr::operator=(const SAGEExpr& Other) {


### PR DESCRIPTION
When compiling with `-DNDEBUG`, the `assert(false && ...)` call will be removed by the preprocessor.  That makes this non-void function look like it could complete without returning a value, and gcc-5.1 rightly complains about that.  But gcc knows that `abort()` never returns, so adding `abort()` after the assertion removes the warning.

Incidentally, this isn’t just about compile-time warnings.  If this unexpected situation ever really did arise at run time, and if the assert call had been preprocessed away, the function really would complete without returning a value, and execution would continue using whatever random junk was sitting on the stack.  Better to abort so we know exactly where things went wrong.
